### PR TITLE
Update kops_edit_instancegroup.md

### DIFF
--- a/docs/cli/kops_edit_instancegroup.md
+++ b/docs/cli/kops_edit_instancegroup.md
@@ -24,7 +24,7 @@ kops edit instancegroup [flags]
 
 ```
   # Edit an instancegroup desired configuration.
-  kops edit ig --name k8s-cluster.example.com node --state=s3://kops-state-1234
+  kops edit ig --name k8s-cluster.example.com nodes --state=s3://kops-state-1234
 ```
 
 ### Options


### PR DESCRIPTION
Update to  `kops edit instancegroup` example. 

Was trying to use command example and discovered that `node` throw an error. Changing `node` to `nodes` resolve it.